### PR TITLE
fixed responsive design of intro section

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -120,23 +120,28 @@ section {
 ---------------------------------------------- */
 .intro {
   background-image: linear-gradient(rgba(0,0,0,.3), rgba(39,43,48,1)), url('{{ site.baseurl }}/images/sp-bg-compressed.jpg');
+  img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #fff;
+  }
   h1 {
     margin-left: auto;
     margin-right: auto;
-    width: 422px;
     line-height: 30px;
     font-size: 20px;
     padding-bottom: 20px;
     margin-bottom: 20px;
     padding-bottom: 13px;
     border-bottom: 1px solid #fff;
-    img {
+    span {
       display: block;
-      margin-left: auto;
-      margin-right: auto;
-      margin-bottom: 20px;
-      padding-bottom: 10px;
-      border-bottom: 1px solid #fff;
+    }
+    span::before {
+      content: attr(data-text);
     }
   }
   .about-button {
@@ -145,8 +150,10 @@ section {
     table-layout: fixed;
     width: 100%;
     .btn-item {
-      display: table-cell;
-      vertical-align: middle;
+      line-height: 70px;
+      .btn {
+        margin-top: 0px !important;
+      }
     }
   }
 }

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -82,31 +82,35 @@ section {
 ---------------------------------------------- */
 .intro {
   background-image: linear-gradient(rgba(0, 0, 0, 0.3), #272b30), url("/images/sp-bg-compressed.jpg"); }
+  .intro img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #fff; }
   .intro h1 {
     margin-left: auto;
     margin-right: auto;
-    width: 422px;
     line-height: 30px;
     font-size: 20px;
     padding-bottom: 20px;
     margin-bottom: 20px;
     padding-bottom: 13px;
     border-bottom: 1px solid #fff; }
-    .intro h1 img {
-      display: block;
-      margin-left: auto;
-      margin-right: auto;
-      margin-bottom: 20px;
-      padding-bottom: 10px;
-      border-bottom: 1px solid #fff; }
+    .intro h1 span {
+      display: block; }
+    .intro h1 span::before {
+      content: attr(data-text); }
   .intro .about-button {
     display: table;
     margin: 0 auto;
     table-layout: fixed;
     width: 100%; }
     .intro .about-button .btn-item {
-      display: table-cell;
-      vertical-align: middle; }
+      line-height: 70px; }
+      .intro .about-button .btn-item .btn {
+        margin-top: 0px !important; }
 
 #join-us .thumbnail {
   padding: 20px;

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -117,21 +117,19 @@
     <div class="container">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <h1>
-            <img src="/images/sotm-logo-white.png" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
-            The Latin American OpenStreetMap Conference
-          </h1>
+          <img src="/images/sotm-logo-white.png" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
+          <h1>The Latin American <span>OpenStreetMap Conference</span></h1>
           <h2>November 29 - December 02</h2>
           <div class="about-button">
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a class="btn btn-default" href="#about" role="button">About the event</a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a href="#about" class="btn btn-circle page-scroll">
                 <i class="fa fa-angle-double-down animated"></i>
               </a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a target="_blank" class="btn btn-default"
               href="http://osmpe.ourproject.org/inscripcion-inscricao-registration/" role="button">
                 Register

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,21 +117,19 @@
     <div class="container">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <h1>
-            <img src="/images/sotm-logo-white.png" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
-            La Conferencia Latinoamericana de OpenStreetMap
-          </h1>
+          <img src="/images/sotm-logo-white.png" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
+          <h1>La Conferencia Latinoamericana <span>de OpenStreetMap</span></h1>
           <h2>29 Noviembre - 02 Diciembre</h2>
           <div class="about-button">
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a class="btn btn-default" href="#about" role="button">Acerca del evento</a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a href="#about" class="btn btn-circle page-scroll">
                 <i class="fa fa-angle-double-down animated"></i>
               </a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a target="_blank" class="btn btn-default"
               href="http://osmpe.ourproject.org/inscripcion-inscricao-registration/" role="button">
                 Registrese
@@ -200,7 +198,7 @@
           <div class="caption text-center">
             <h3>Facultad de Ciencias Sociales<br>Universidad Nacional Mayor de San Marcos</h3>
             <p class="venue">
-		<a target="_blank" href="http://csociales.unmsm.edu.pe/"> La Facultad de CCSS </a> está ubicada en la Ciudad Universitaria entre las Avenidas 			Univesitaria y Venezuela. La entrada más próxima es la puerta Nº 3 del campus que se encuentra en la Calle Germán Amézaga. La accesibilidad en 			silla de ruedas es regular. 
+		<a target="_blank" href="http://csociales.unmsm.edu.pe/"> La Facultad de CCSS </a> está ubicada en la Ciudad Universitaria entre las Avenidas 			Univesitaria y Venezuela. La entrada más próxima es la puerta Nº 3 del campus que se encuentra en la Calle Germán Amézaga. La accesibilidad en 			silla de ruedas es regular.
             </p>
           </div>
         </div>

--- a/docs/pt/index.html
+++ b/docs/pt/index.html
@@ -117,21 +117,19 @@
     <div class="container">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <h1>
-            <img src="/images/sotm-logo-white.png" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
-            A Conferência Latino-americana do OpenStreetMap
-          </h1>
+          <img src="/images/sotm-logo-white.png" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
+          <h1>A Conferência Latino-americana <span>do OpenStreetMap</span></h1>
           <h2>29 Novembro - 02 Dezembro</h2>
           <div class="about-button">
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a class="btn btn-default" href="#about" role="button">Sobre o evento</a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a href="#about" class="btn btn-circle page-scroll">
                 <i class="fa fa-angle-double-down animated"></i>
               </a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a target="_blank" class="btn btn-default"
               href="http://osmpe.ourproject.org/inscripcion-inscricao-registration/" role="button">
                 Inscreva-se

--- a/en/index.html
+++ b/en/index.html
@@ -9,21 +9,19 @@ lang: en
     <div class="container">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <h1>
-            <img src="{{ "/images/sotm-logo-white.png" | relative_url }}" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
-            The Latin American OpenStreetMap Conference
-          </h1>
+          <img src="{{ "/images/sotm-logo-white.png" | relative_url }}" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
+          <h1>The Latin American <span>OpenStreetMap Conference</span></h1>
           <h2>November 29 - December 02</h2>
           <div class="about-button">
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a class="btn btn-default" href="#about" role="button">About the event</a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a href="#about" class="btn btn-circle page-scroll">
                 <i class="fa fa-angle-double-down animated"></i>
               </a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a target="_blank" class="btn btn-default"
               href="http://osmpe.ourproject.org/inscripcion-inscricao-registration/" role="button">
                 Register

--- a/index.html
+++ b/index.html
@@ -9,21 +9,19 @@ lang: es
     <div class="container">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <h1>
-            <img src="{{ "/images/sotm-logo-white.png" | relative_url }}" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
-            La Conferencia Latinoamericana de OpenStreetMap
-          </h1>
+          <img src="{{ "/images/sotm-logo-white.png" | relative_url }}" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
+          <h1>La Conferencia Latinoamericana <span>de OpenStreetMap</span></h1>
           <h2>29 Noviembre - 02 Diciembre</h2>
           <div class="about-button">
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a class="btn btn-default" href="#about" role="button">Acerca del evento</a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a href="#about" class="btn btn-circle page-scroll">
                 <i class="fa fa-angle-double-down animated"></i>
               </a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a target="_blank" class="btn btn-default"
               href="http://osmpe.ourproject.org/inscripcion-inscricao-registration/" role="button">
                 Registrese
@@ -79,7 +77,7 @@ lang: es
           <div class="caption text-center">
             <h3>Facultad de Ciencias Sociales<br>Universidad Nacional Mayor de San Marcos</h3>
             <p class="venue">
-		<a target="_blank" href="http://csociales.unmsm.edu.pe/"> La Facultad de CCSS </a> está ubicada en la Ciudad Universitaria entre las Avenidas 			Univesitaria y Venezuela. La entrada más próxima es la puerta Nº 3 del campus que se encuentra en la Calle Germán Amézaga. La accesibilidad en 			silla de ruedas es regular. 
+		<a target="_blank" href="http://csociales.unmsm.edu.pe/"> La Facultad de CCSS </a> está ubicada en la Ciudad Universitaria entre las Avenidas 			Univesitaria y Venezuela. La entrada más próxima es la puerta Nº 3 del campus que se encuentra en la Calle Germán Amézaga. La accesibilidad en 			silla de ruedas es regular.
             </p>
           </div>
         </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -9,21 +9,19 @@ lang: pt
     <div class="container">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <h1>
-            <img src="{{ "/images/sotm-logo-white.png" | relative_url }}" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
-            A Conferência Latino-americana do OpenStreetMap
-          </h1>
+          <img src="{{ "/images/sotm-logo-white.png" | relative_url }}" alt="State of the Map LATAM - Lima 2017" class="img-responsive">
+          <h1>A Conferência Latino-americana <span>do OpenStreetMap</span></h1>
           <h2>29 Novembro - 02 Dezembro</h2>
           <div class="about-button">
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a class="btn btn-default" href="#about" role="button">Sobre o evento</a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a href="#about" class="btn btn-circle page-scroll">
                 <i class="fa fa-angle-double-down animated"></i>
               </a>
             </span>
-            <span class="btn-item">
+            <span class="col-xs-12 col-sm-4 btn-item">
               <a target="_blank" class="btn btn-default"
               href="http://osmpe.ourproject.org/inscripcion-inscricao-registration/" role="button">
                 Inscreva-se


### PR DESCRIPTION
I fix the responsive design of intro section (1st page), here some details:
* separete `img` inner `h1`,
* fix vertical-lign of buttons,
* fix one column of buttons for small phones/tablets

before
![screen shot 2017-04-25 at 16 10 27](https://cloud.githubusercontent.com/assets/1282371/25406278/21e52b1e-29d4-11e7-88d4-6ff679dc1535.jpeg)
![screen shot 2017-04-25 at 16 10 31](https://cloud.githubusercontent.com/assets/1282371/25406279/21ea5a44-29d4-11e7-918a-6110a7f1a8b6.jpeg)

after
![screen shot 2017-04-25 at 16 10 09](https://cloud.githubusercontent.com/assets/1282371/25406293/2d7b68bc-29d4-11e7-993e-0a66af78d11d.jpeg)
![screen shot 2017-04-25 at 16 10 14](https://cloud.githubusercontent.com/assets/1282371/25406292/2d738020-29d4-11e7-9123-c41f95d193f8.jpeg)

